### PR TITLE
fix bug new line

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BMSCApp
 Title: Interface for Bayesian Model Selection under Constraints
-Version: 22.10.1
+Version: 22.12.1
 Authors@R: c(
     person("Marcus", "Groß", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/R/03-modelEstimation.R
+++ b/R/03-modelEstimation.R
@@ -206,8 +206,8 @@ modelEstimation <- function(input, output, session, data) {
     
     model <- withProgress({constrSelEst(
                 formula = FORMULA,
-                mustInclude = mustInclude, 
-                mustExclude = mustExclude,
+                mustInclude = input$mustInclude, 
+                mustExclude = input$mustExclude,
                  maxExponent = input$maxExp,
                  interactionDepth = input$interactionDepth,
                  categorical = xCat,

--- a/R/03-modelEstimation.R
+++ b/R/03-modelEstimation.R
@@ -201,11 +201,23 @@ modelEstimation <- function(input, output, session, data) {
       return(NULL)
     }
     set.seed(1234)
+    
+    #for longer var list "\\n  " appears which has to be stripped
+    if(is.null(input$mustInclude)){
+      mustInclude <- gsub('[\n ]', '', input$mustInclude)
+    } else {
+      mustInclude <- NULL
+    }
+    if(is.null(input$mustExclude)){
+      mustExclude <- gsub('[\n ]', '', input$mustExclude)
+    } else {
+      mustExclude <- NULL
+    }
+    
     model <- withProgress({constrSelEst(
                 formula = FORMULA,
-                #for longer var list "\\n  " appears which has to be stripped
-                mustInclude = gsub('[\n ]', '', input$mustInclude), 
-                mustExclude = gsub('[\n ]', '', input$mustExclude),
+                mustInclude = mustInclude, 
+                mustExclude = mustExclude,
                  maxExponent = input$maxExp,
                  interactionDepth = input$interactionDepth,
                  categorical = xCat,

--- a/R/03-modelEstimation.R
+++ b/R/03-modelEstimation.R
@@ -201,11 +201,11 @@ modelEstimation <- function(input, output, session, data) {
       return(NULL)
     }
     set.seed(1234)
-    
     model <- withProgress({constrSelEst(
                 formula = FORMULA,
-                mustInclude = input$mustInclude,
-                mustExclude = input$mustExclude,
+                #for longer var list "\\n  " appears which has to be stripped
+                mustInclude = gsub('[\n ]', '', input$mustInclude), 
+                mustExclude = gsub('[\n ]', '', input$mustExclude),
                  maxExponent = input$maxExp,
                  interactionDepth = input$interactionDepth,
                  categorical = xCat,

--- a/R/03-modelEstimation.R
+++ b/R/03-modelEstimation.R
@@ -96,7 +96,9 @@ modelEstimation <- function(input, output, session, data) {
                   interactionDepth = input$interactionDepth,
                   intercept = input$intercept,
                   categorical = xCat)
-    return(strsplit(strsplit(as.character(FORMULA)[3], "~")[[1]], " \\+ ")[[1]])
+    
+    ret <- gsub('[\n ]', '', strsplit(strsplit(as.character(FORMULA)[3], "~")[[1]], " \\+ ")[[1]])
+    return(ret)
     } else {
       return("")
     }
@@ -202,17 +204,6 @@ modelEstimation <- function(input, output, session, data) {
     }
     set.seed(1234)
     
-    #for longer var list "\\n  " appears which has to be stripped
-    if(!is.null(input$mustInclude)){
-      mustInclude <- gsub('[\n ]', '', input$mustInclude)
-    } else {
-      mustInclude <- NULL
-    }
-    if(!is.null(input$mustExclude)){
-      mustExclude <- gsub('[\n ]', '', input$mustExclude)
-    } else {
-      mustExclude <- NULL
-    }
     model <- withProgress({constrSelEst(
                 formula = FORMULA,
                 mustInclude = mustInclude, 

--- a/R/03-modelEstimation.R
+++ b/R/03-modelEstimation.R
@@ -213,7 +213,6 @@ modelEstimation <- function(input, output, session, data) {
     } else {
       mustExclude <- NULL
     }
-    browser()
     model <- withProgress({constrSelEst(
                 formula = FORMULA,
                 mustInclude = mustInclude, 

--- a/R/03-modelEstimation.R
+++ b/R/03-modelEstimation.R
@@ -203,17 +203,17 @@ modelEstimation <- function(input, output, session, data) {
     set.seed(1234)
     
     #for longer var list "\\n  " appears which has to be stripped
-    if(is.null(input$mustInclude)){
+    if(!is.null(input$mustInclude)){
       mustInclude <- gsub('[\n ]', '', input$mustInclude)
     } else {
       mustInclude <- NULL
     }
-    if(is.null(input$mustExclude)){
+    if(!is.null(input$mustExclude)){
       mustExclude <- gsub('[\n ]', '', input$mustExclude)
     } else {
       mustExclude <- NULL
     }
-    
+    browser()
     model <- withProgress({constrSelEst(
                 formula = FORMULA,
                 mustInclude = mustInclude, 


### PR DESCRIPTION
This is a minor bug fix: The shiny element produced "\n" at some places in the input string and thus variable matching did not work anymore