### PR TITLE
add tryCatch to vif() calculation (#9)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BMSCApp
 Title: Interface for Bayesian Model Selection under Constraints
-Version: 23.07.0.2
+Version: 23.07.0.3
 Authors@R: c(
     person("Marcus", "Groß", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),


### PR DESCRIPTION
I was able to reproduce the issue, however, this is model related and [happens when variables are perfectly correlated](https://www.statology.org/r-aliased-coefficients-in-the-model/).

I now catch the error with a pop up, so the user knows from which function the error message results. Now, the app does not crash anymore.

![image](https://github.com/Pandora-IsoMemo/bmsc-app/assets/16759098/5690dd5e-d99d-414b-94cc-9a6fed008b38)
